### PR TITLE
Fix name of libsodium chacha20poly1305 keygen function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,7 @@ export class DIDComm {
     }
 
     private prepareRecipientKeys(toKeys: any, fromKeys: any = null) {
-        const cek = this.sodium.crypto_secretstream_chacha20poly1305_keygen()
+        const cek = this.sodium.crypto_aead_chacha20poly1305_ietf_keygen()
         const recips: any[] = []
 
         toKeys.forEach((targetVk: any) => {


### PR DESCRIPTION
Hi @kdenhartog, it seems like in your latest changes you didn't hit the precise libsodium binding, the encryption/decryption test is failing right now on this:
```
TypeError: this.sodium.crypto_secretstream_chacha20poly1305_ietf_keygen is not a function

      141 | 
      142 |     private prepareRecipientKeys(toKeys: any, fromKeys: any = null) {
    > 143 |         const cek = this.sodium.crypto_secretstream_chacha20poly1305_ietf_keygen()
          |                                 ^
```

I think I fixed it (the test is passing) but it would be great if someone could verify this is really the correct libsodium call. Based on [this](https://libsodium.gitbook.io/doc/quickstart#how-can-a-and-b-securely-communicate-without-a-pre-shared-secret-key) it  sounds like `crypto_secretstream_*` and `crypto_aead_*` are equivalent? 
Also made my judgement based on [this](https://github.com/jedisct1/libsodium/blob/df5c9e95c9da4402059ec23351d9c1c45a698989/ChangeLog#L333) and [this](https://github.com/jedisct1/libsodium/blob/df5c9e95c9da4402059ec23351d9c1c45a698989/ChangeLog#L192)